### PR TITLE
adding support for search filtered versioning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,6 +45,13 @@ version_params:
   version_dir: Archive
   tocversion_dir: versions
   versioning: true
+
+  # Disable so older versions cannot be searched
+  allow_search: true  
+
+  # Allow these versions to be searched
+  search_versions:
+    - Previous
   latest: Current
   versions:
     - Current

--- a/_docs/versioning.md
+++ b/_docs/versioning.md
@@ -76,6 +76,11 @@ version_params:
   tocversion_dir: versions
   versioning: true
   latest: current
+  allow_search: true  
+  search_versions:
+    - main
+    - current
+    - beta
   versions:
     - main
     - current
@@ -97,6 +102,8 @@ version_params:
 | version_dir | This is the directory where all the alternative versions of the documentation will be contained beneath the _docs directory <br/>i.e. setting this to the value of Archive (Note: **No** trailing slash) will mean all alternative versions will be found in _docs/Archive/ | Archive
 |  tocversion_dir | This is the directory inside your _data directory where Docsy Jekyll will find the alternative TOC files that are used for other versions of the documentation. You can configure this to be whatever name you like, just ensure your other TOCs can be found there! | versions 
 | latest | From the list of versions this determines the one which relates to your base docs directory.<br/> Note the url for your docs will not contain a version identifier for this particular version| current \| v3.1
+| allow_search | A boolean to indicate if we should allow searching over versions. If False, only the current is displayed in results | true \| false 
+| search_version | A list of versions to include in the search. Current or latest will be tagged with the site.tag_color, the rest will be gray | current \| previous
 | versions | A list of versions you wish to display in the version dropdown <br/> Note that there are several special keywords that can be used: current, main, alpha, beta, rc and pre, see below for more details  | current \| v1.0 \| v2.1.3
 
 {% include alert.html type="warning" title="Note: The versions listed must have the same name as the folder name in which that version of the documentation resides otherwise jekyll it will not find it! The exception is the version 'current' which does not have a separate folder and is used to inform jekyll to utilize the base _docs folder." %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,12 +13,12 @@
 <link rel="apple-touch-icon" href="{{ site.baseurl }}/assets/favicons/apple-touch-icon-180x180.png" sizes="180x180">
 <link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/favicon-16x16.png" sizes="16x16">
 <link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/favicon-32x32.png" sizes="32x32">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-36x36.png" sizes="36x36">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-48x48.png" sizes="48x48">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-72x72.png" sizes="72x72">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-96x196.png" sizes="96x196">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-144x144.png" sizes="144x144">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-192x192.png"sizes="192x192">
+<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-icon-36x36.png" sizes="36x36">
+<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-icon-48x48.png" sizes="48x48">
+<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-icon-72x72.png" sizes="72x72">
+<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-icon-96x196.png" sizes="96x196">
+<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-icon-144x144.png" sizes="144x144">
+<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-icon-192x192.png"sizes="192x192">
 
 <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
 <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -65,7 +65,7 @@ excluded_in_search: true
 
 		if (results.length) {
 			var resultsHTML = "";
-                       var searchVersions = [{% for v in site.version_params.search_versions %}"{{ v }}",{% endfor %}"all"]
+			var searchVersions = [{% for v in site.version_params.search_versions %}"{{ v }}",{% endfor %}"all"]
 			results.forEach(function (result) {
 			
   				var item = window.data[result.ref]
@@ -89,17 +89,17 @@ excluded_in_search: true
 					contentPreview = getPreview(query, item.content, 170),
 					titlePreview = getPreview(query, item.title);
 
-                                       // If we only allow one version (all) skip adding a badge
-                                       if (searchVersions.length == 1 ||  "{{ site.version_params.versioning }}" == "false"){
-                                         versionBadge = ""
+					// If we only allow one version (all) skip adding a badge
+					if (searchVersions.length == 1 ||  "{{ site.version_params.versioning }}" == "false"){
+						versionBadge = ""
 
 					// Any older version shows up in gray
-                                       } else if (item.version != "all") {
-                                          versionBadge = "<span class='badge badge-secondary'>" + item.version + "</span>"
+					} else if (item.version != "all") {
+						versionBadge = "<span class='badge badge-secondary'>" + item.version + "</span>"
 
 					// Current is blue (primary)
-                                       } else {
-                                          versionBadge = "<span class='badge badge-{{ site.tag_color }}'>Current</span>"
+					} else {
+						versionBadge = "<span class='badge badge-{{ site.tag_color }}'>Current</span>"
                                        }
 					resultsHTML += "<li><h4><a href='{{ site.baseurl }}" + item.url.trim() + "'>" + titlePreview + "</a></h4><p>" + versionBadge +"<small>" + contentPreview + "</small></p></li>";
 				}

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -65,13 +65,43 @@ excluded_in_search: true
 
 		if (results.length) {
 			var resultsHTML = "";
+                       var searchVersions = [{% for v in site.version_params.search_versions %}"{{ v }}",{% endfor %}"all"]
 			results.forEach(function (result) {
-
+			
   				var item = window.data[result.ref]
+
+				// Versioning is disabled
+				if (("{{ site.version_params.versioning }}" == "false") && (item.version != "all")) {
+				    return
+				}
+
+				// Skip result if showing versions disabled
+				if (("{{ site.version_params.allow_search }}" == "false") && (item.version != "all")) {
+				    return
+				}
+
+                               // Skip result if version not in all or versions allowed for search
+				if (("{{ site.version_params.versioning }}" == "true") && ("{{ site.version_params.allow_search }}" == "true") && (!searchVersions.includes(item.version))) {
+				    return
+				}
+
                                 if (item.title) {
 					contentPreview = getPreview(query, item.content, 170),
 					titlePreview = getPreview(query, item.title);
-					resultsHTML += "<li><h4><a href='{{ site.baseurl }}" + item.url.trim() + "'>" + titlePreview + "</a></h4><p><small>" + contentPreview + "</small></p></li>";
+
+                                       // If we only allow one version (all) skip adding a badge
+                                       if (searchVersions.length == 1 ||  "{{ site.version_params.versioning }}" == "false"){
+                                         versionBadge = ""
+
+					// Any older version shows up in gray
+                                       } else if (item.version != "all") {
+                                          versionBadge = "<span class='badge badge-secondary'>" + item.version + "</span>"
+
+					// Current is blue (primary)
+                                       } else {
+                                          versionBadge = "<span class='badge badge-{{ site.tag_color }}'>Current</span>"
+                                       }
+					resultsHTML += "<li><h4><a href='{{ site.baseurl }}" + item.url.trim() + "'>" + titlePreview + "</a></h4><p>" + versionBadge +"<small>" + contentPreview + "</small></p></li>";
 				}
 			});
 

--- a/pages/search.html
+++ b/pages/search.html
@@ -13,15 +13,17 @@ excluded_in_search: true
 
 <ul id="search-results"></ul>
 
+{% capture version_prefix %}/docs/{{ site.version_params.version_dir }}/{% endcapture %}
 <script>
 	window.data = {
 		{% for post in site.docs %}
 				{% unless post.excluded_in_search %}
 					{% if added %},{% endif %}
-					{% assign added = false %}
+					{% assign added = false %}{% assign version_dir = post.url | split: version_prefix %}{% assign docs_version = version_dir[1] | split: "/" %}
 					"{{ post.url | slugify }}": {
 						"id": "{{ post.url | slugify }}",
 						"title": "{{ post.title | xml_escape }}",
+						"version": "{% if post.url contains site.version_params.version_dir %}{{ docs_version[0] }}{% else %}all{% endif %}",
 						"categories": "{{ post.categories | join: ", " | xml_escape }}",
 						"url": " {{ post.url | xml_escape }}",
 						"content": {{ post.content | strip_html | replace_regex: "[\s/\n]+"," " | strip | jsonify }}
@@ -36,6 +38,7 @@ excluded_in_search: true
 					"{{ post.url | slugify }}": {
 						"id": "{{ post.url | slugify }}",
 						"title": "{{ post.title | xml_escape }}",
+						"version": "all", 
 						"categories": "{{ post.categories | join: ", " | xml_escape }}",
 						"url": " {{ post.url | xml_escape }}",
 						"content": {{ post.content | strip_html | replace_regex: "[\s/\n]+"," " | strip | jsonify }}
@@ -50,6 +53,7 @@ excluded_in_search: true
 					"{{ post.url | slugify }}": {
 						"id": "{{ post.url | slugify }}",
 						"title": "{{ post.title | xml_escape }}",
+						"version": "all",
 						"categories": "{{ post.categories | join: ", " | xml_escape }}",
 						"url": " {{ post.url | xml_escape }}",
 						"content": {{ post.content | strip_html | replace_regex: "[\s/\n]+"," " | strip | jsonify }}


### PR DESCRIPTION
hey @steve-lyons! 

I couldn't sleep so I was like "Hey, let's write some JavaScript!" and so here is an idea for how to filter versions for search. In the below you will see:

1. I add a field "version" to the search metadata in pages/search.html. If the page is in the version_dir, we split it up to derive it, otherwise (all other cases) are "all" to indicate current or "other content in site"
2. In search.js I then do a filter over results, eliminating anything != "all" (not current) if a. versioning is disabled or search for versions if disabled, or b. it's enabled, but not in the list the user wants to include.
3. I then create a badge for the result in a similar fashion (see image below). If versioning is disabled for search by any means, we don't include a badge.

I updated the docs, and also noticed a 404 on the android icons (the path was wrong) and fixed that too! So feel free to use this /merge into the working PR (or discard it if it's not to your liking.) Let me know if you want me to change anything, also please feel free to merge and tweak to your desire!

![image](https://user-images.githubusercontent.com/814322/175921340-6a826cec-42bc-46ab-84ce-a8efdf10fdbc.png)

And I should probably try to get some sleep :)

Signed-off-by: vsoch <vsoch@users.noreply.github.com>